### PR TITLE
Update container-run.sh

### DIFF
--- a/container-run.sh
+++ b/container-run.sh
@@ -165,9 +165,9 @@ run_container() {
     $CONTAINER_ENGINE run -d \
         --name oc-mirror-web-app \
         -p 3000:3001 \
-        -v "$(pwd)/data:/app/data" \
+        -v "$(pwd)/data:/app/data:z" \
         -v "$(pwd)/downloads:/app/downloads" \
-        -v "$(pwd)/pull-secret/pull-secret.json:/app/pull-secret.json:ro" \
+        -v "$(pwd)/pull-secret/pull-secret.json:/app/pull-secret.json:z" \
         -e NODE_ENV=production \
         -e PORT=3001 \
         -e STORAGE_DIR=/app/data \


### PR DESCRIPTION
On RHEL selinux prevents the sharing of the file system.  I have therefore added :z to enable this.  I think you may need to be more linux specific in order to not affect other linux distros