### PR TITLE
Fix operator channel processing and additionalImages display

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,11 @@ debug-output.log
 
 # Exclude temporary files
 *.tmp
-*.temp 
+*.temp
+
+# Exclude cache directories (will be created at runtime)
+data/cache/
+
+# Exclude runtime data directories (will be created at runtime)
+data/logs/
+data/operations/

--- a/src/components/MirrorConfig.js
+++ b/src/components/MirrorConfig.js
@@ -547,10 +547,14 @@ const MirrorConfig = () => {
       kind: 'ImageSetConfiguration',
       apiVersion: 'mirror.openshift.io/v2alpha1',
       mirror: {
-        operators: [],
-        additionalImages: config.mirror.additionalImages
+        operators: []
       }
     };
+
+    // Only add additionalImages if it has content
+    if (config.mirror.additionalImages && config.mirror.additionalImages.length > 0) {
+      cleanConfig.mirror.additionalImages = config.mirror.additionalImages;
+    }
 
     // Only add platform section if channels exist
     if (config.mirror.platform.channels && config.mirror.platform.channels.length > 0) {


### PR DESCRIPTION
## 🔧 Fix operator channel processing and additionalImages display

This PR resolves several critical issues with operator channel processing and YAML preview display.

### 🐛 Issues Fixed

1. **volsync-product Channel Processing**
   - Fixed missing versioned bundle names for operators with only individual channel files
   - Now correctly extracts versions from channel entries (e.g., `volsync-product.v0.12.0`)
   - Shows 21 versions (0.8.0 → 0.13.0) instead of just generic channels
   - Enables correct min/max version calculation in dropdowns

2. **additionalImages Display Fix**
   - Empty `additionalImages: []` no longer appears in YAML Preview
   - Cleaner, more professional output when no additional images are configured

3. **Channel Processing Logic**
   - Enhanced to handle both legacy string format and new array format for channels
   - Works for all operators across all catalogs and versions
   - Fixed channel extraction for operators with only individual channel files

4. **Container Build Optimization**
   - Updated `.dockerignore` to exclude runtime data directories
   - Prevents "no space left on device" errors during container builds

### 🔧 Technical Changes

- **`fetch-catalogs-host.sh`**: Enhanced to process individual channel files when `catalog.json` is not available
- **`server/index.js`**: Fixed channel processing logic to handle both legacy and new channel formats
- **`src/components/MirrorConfig.js`**: Fixed additionalImages display to hide when empty
- **`.dockerignore`**: Updated to exclude runtime data directories from container builds

### ✅ Testing

- ✅ volsync-product now shows correct min/max versions
- ✅ rhsso-operator still working (58 versions)
- ✅ kubernetes-nmstate-operator still working (48 versions)
- ✅ topology-aware-lifecycle-manager still working
- ✅ additionalImages no longer appears when empty
- ✅ All operators fetching and displaying correctly

### 🎯 Impact

This resolves the core issue where operators like volsync-product were not displaying correct min/max versions in the Mirror Configuration dropdowns, and improves the overall user experience by providing cleaner YAML output.