### PR TITLE
Upgrade from Node.js 20 to Node.js 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for production
-FROM node:20-slim AS builder
+FROM node:22-slim AS builder
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
@@ -40,7 +40,7 @@ RUN npm run lint:fix || true
 RUN npm run build
 
 # Production stage
-FROM node:20-slim AS production
+FROM node:22-slim AS production
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -90,7 +90,7 @@ chmod +x quay-run.sh
 ## 📋 What's Included
 
 The containerized version includes:
-- ✅ **Node.js 20** runtime
+- ✅ **Node.js 22** runtime
 - ✅ **OpenShift CLI (oc)** 
 - ✅ **oc-mirror v2** 
 - ✅ **All dependencies** pre-installed

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ For issues and questions:
 
 ### Container Runtime Requirements
 - **Podman**: 4.0+ ✅ Required
-- **Node.js**: 18+ (included in container)
+- **Node.js**: 22 (included in container)
 
 ### Architecture Support
 - **AMD64 (x86_64)**: ✅ Fully supported

--- a/container-run.sh
+++ b/container-run.sh
@@ -82,7 +82,7 @@ fix_permissions() {
         return 0
     fi
     
-    # Check if directories are already owned by container user (UID 1000 - node user in node:20-slim image)
+    # Check if directories are already owned by container user (UID 1000 - node user in node:22-slim image)
     local data_owner=$(stat -c '%u' data/ 2>/dev/null || echo "unknown")
     
     # Container runs as node user (UID 1000), check if ownership needs fixing

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "proxy": "http://localhost:3001",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=22.0.0",
     "npm": ">=9.0.0"
   }
 } 

--- a/quay-run.sh
+++ b/quay-run.sh
@@ -110,7 +110,7 @@ fix_permissions() {
         return 0
     fi
     
-    # Check if directories are already owned by container user (UID 1000 - node user in node:20-slim image)
+    # Check if directories are already owned by container user (UID 1000 - node user in node:22-slim image)
     local data_owner=$(stat -c '%u' data/ 2>/dev/null || echo "unknown")
     
     # Container runs as node user (UID 1000), check if ownership needs fixing


### PR DESCRIPTION
## Summary
This PR upgrades the application from Node.js 20 (deprecated) to Node.js 22.

## Changes
- Updated `Dockerfile` to use `node:22-slim` instead of `node:20-slim` (both builder and production stages)
- Updated `package.json` engines field to require Node.js >=22.0.0
- Updated documentation (README.md, QUICKSTART.md) to reflect Node.js 22
- Updated shell script comments to reference `node:22-slim`

## Verification
- Application builds successfully with Node.js 22.21.1
- All API endpoints functioning correctly
- Web interface loads and operates normally
- Container health checks passing

## Testing
- ✅ Build completed successfully
- ✅ Container runs with Node.js v22.21.1
- ✅ API endpoints verified
- ✅ Web interface accessible and functional