### PR TITLE
Add archiveSize option and improve tooltips

### DIFF
--- a/src/components/MirrorConfig.js
+++ b/src/components/MirrorConfig.js
@@ -9,6 +9,7 @@ const MirrorConfig = () => {
   const [config, setConfig] = useState({
     kind: 'ImageSetConfiguration',
     apiVersion: 'mirror.openshift.io/v2alpha1',
+    archiveSize: '',  // Size in GiB - optional parameter
     mirror: {
       platform: {
         channels: [],
@@ -693,6 +694,11 @@ const MirrorConfig = () => {
       }
     };
 
+    // Add archiveSize only if set
+    if (config.archiveSize && parseInt(config.archiveSize) > 0) {
+      cleanConfig.archiveSize = parseInt(config.archiveSize);
+    }
+
     // Only add additionalImages if it has content
     if (config.mirror.additionalImages && config.mirror.additionalImages.length > 0) {
       cleanConfig.mirror.additionalImages = config.mirror.additionalImages;
@@ -1253,6 +1259,40 @@ const MirrorConfig = () => {
             >
               📋 Copy YAML
             </button>
+          </div>
+          
+          <div className="card" style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+            <div className="form-group">
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                Archive Size (GiB)
+                <span 
+                  title="Maximum size (in GiB) for archive files when mirroring to disk. Leave empty to use default behavior."
+                  onClick={() => toast.info('Maximum size (in GiB) for archive files when mirroring to disk. Leave empty to use default behavior.', { autoClose: 5000 })}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '18px',
+                    height: '18px',
+                    borderRadius: '50%',
+                    border: '1.5px solid #007bff',
+                    color: '#007bff',
+                    fontSize: '12px',
+                    fontWeight: 'bold',
+                    cursor: 'pointer'
+                  }}
+                >?</span>
+              </label>
+              <input 
+                type="number" 
+                className="form-control"
+                value={config.archiveSize}
+                onChange={(e) => setConfig(prev => ({ ...prev, archiveSize: e.target.value }))}
+                min="1"
+                placeholder="e.g., 4"
+                style={{ maxWidth: '200px' }}
+              />
+            </div>
           </div>
           
           <div className="yaml-preview-container">

--- a/src/components/MirrorOperations.js
+++ b/src/components/MirrorOperations.js
@@ -31,7 +31,6 @@ const MirrorOperations = () => {
   
   // Mirror destination subdirectory state
   const [mirrorDestinationSubdir, setMirrorDestinationSubdir] = useState('');
-  const [showTooltip, setShowTooltip] = useState(false);
   const [notifiedOperations, setNotifiedOperations] = useState(new Set());
   const [showMirrorLocation, setShowMirrorLocation] = useState({});
 
@@ -625,21 +624,20 @@ const MirrorOperations = () => {
                 style={{ 
                   cursor: 'pointer', 
                   color: '#007bff', 
-                  fontSize: '0.9rem',
+                  fontSize: '12px',
                   fontWeight: 'bold',
                   width: '18px',
                   height: '18px',
                   borderRadius: '50%',
-                  border: '1px solid #007bff',
+                  border: '1.5px solid #007bff',
                   display: 'inline-flex',
                   alignItems: 'center',
                   justifyContent: 'center',
-                  backgroundColor: '#f0f8ff',
                   lineHeight: '1',
                   flexShrink: 0
                 }}
-                onClick={() => setShowTooltip(!showTooltip)}
-                title="Click for help"
+                onClick={() => toast.info('Mirror files are saved to data/mirrors/<subdirectory>. Leave empty for "default". The subdirectory is created automatically with correct permissions.', { autoClose: 5000 })}
+                title="Mirror files are saved to data/mirrors/<subdirectory>. Leave empty for 'default'. Click for more info."
               >
                 ?
               </span>
@@ -668,46 +666,6 @@ const MirrorOperations = () => {
           >
             {loading ? <div className="loading"></div> : '▶️ Start Operation'}
           </button>
-          {showTooltip && (
-            <div style={{
-              position: 'absolute',
-              top: '100%',
-              left: '0',
-              marginTop: '0.5rem',
-              padding: '0.75rem',
-              backgroundColor: '#fff',
-              border: '1px solid #dee2e6',
-              borderRadius: '4px',
-              fontSize: '0.85rem',
-              lineHeight: '1.6',
-              zIndex: 1000,
-              boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
-              maxWidth: '400px',
-              width: 'max-content'
-            }}>
-              <strong>How it works:</strong>
-              <br />
-              • Mirror files are saved to <code>data/mirrors/</code> on your host (this path is fixed and cannot be changed)
-              <br />
-              • If you leave this field empty, files are saved to <code>data/mirrors/default</code>
-              <br />
-              • If you enter a subdirectory name (e.g., <code>odf</code>), files are saved to <code>data/mirrors/odf</code>
-              <br />
-              • The subdirectory is created automatically if it doesn't exist, with correct permissions
-              <br />
-              <br />
-              <strong>Examples:</strong>
-              <br />
-              • Empty field → <code>data/mirrors/default</code>
-              <br />
-              • Enter <code>odf</code> → <code>data/mirrors/odf</code>
-              <br />
-              • Enter <code>production</code> → <code>data/mirrors/production</code>
-              <br />
-              <br />
-              <strong>Note:</strong> All files persist across container restarts since they are stored on your host filesystem.
-            </div>
-          )}
         </div>
         
         {runningOperation && (


### PR DESCRIPTION
## Changes

### New Features
- **Archive Size Parameter**: Added `archiveSize` option to ImageSetConfiguration in the Preview tab
  - Allows users to specify maximum archive size (in GiB) for mirroring to disk
  - Optional field - leave empty for default behavior

### Improvements
- **Tooltip Consistency**: Updated tooltip behavior across components
  - Archive Size field: hover shows native tooltip, click shows toast notification
  - Mirror Destination Subdirectory: updated to use same hover + click pattern

### Bug Fixes
- **Channel Extraction Fix**: Fixed `fetch-catalogs-host.sh` script to correctly extract all channels for operators like `quay-operator` and `quay-bridge-operator`
  - Now properly filters for `olm.channel` schema objects
  - Scans additional JSON files in operator directories for channel definitions