### PR TITLE
Release v4.4: Dockerfile optimization, audit improvements, and version cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Install test catalog fixture
         run: cp -rT tests/fixtures/catalog-data catalog-data
 
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
       - name: Run unit and integration tests
         run: npm run test
 
@@ -73,3 +79,15 @@ jobs:
               echo "Skipping $script (not present, gitignored)"
             fi
           done
+
+  container-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Podman
+        run: sudo apt-get update && sudo apt-get install -y podman
+
+      - name: Build container image
+        run: podman build -t oc-mirror-web-app:ci .

--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,6 @@ audit-reports/
 mirror/
 start-local.sh
 clean-stale-ports.sh
-scripts/audit-fetch-catalogs.mjs
 
 # Playwright
 test-results/

--- a/API.md
+++ b/API.md
@@ -107,7 +107,6 @@ Get system information and health status.
   "success": true,
   "data": {
     "ocMirrorVersion": "2.0.0",
-    "ocVersion": "4.18.0",
     "systemArch": "x86_64",
     "availableSpace": 107374182400,
     "totalSpace": 500107862016,

--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # OC Mirror v2 Web Application - API Documentation
 
-**Current Version: v4.3**
+**Current Version: v4.4**
 
 ## Overview
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-slim AS builder
 
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG VERSION=4.3
+ARG VERSION=4.4
 
 WORKDIR /app
 RUN npm install -g npm@11.6.2
@@ -31,46 +31,54 @@ RUN mkdir -p /app/catalog-data-minimal && \
     done
 RUN npx vite build
 
+# Fetch oc-mirror only; wget/tar stay in this stage (not copied to production).
+FROM node:22-slim AS downloader
+
+ARG TARGETARCH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wget ca-certificates tar libgpgme11 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV OCMIRROR_URL_AMD64="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/oc-mirror.tar.gz"
+ENV OCMIRROR_URL_ARM64="https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/stable/oc-mirror.rhel9.tar.gz"
+
+RUN set -eux; \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      OCMIRROR_URL=$OCMIRROR_URL_ARM64; \
+    else \
+      OCMIRROR_URL=$OCMIRROR_URL_AMD64; \
+    fi; \
+    wget -O /tmp/oc-mirror.tar.gz "$OCMIRROR_URL"; \
+    tar -xzf /tmp/oc-mirror.tar.gz -C /usr/local/bin/; \
+    chmod +x /usr/local/bin/oc-mirror; \
+    rm /tmp/oc-mirror.tar.gz; \
+    which oc-mirror; \
+    oc-mirror version
+
 FROM node:22-slim AS production
 
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG VERSION=4.3
-ARG TARGETARCH
+ARG VERSION=4.4
 
-RUN npm install -g npm@11.6.2
+COPY --from=downloader /usr/local/bin/oc-mirror /usr/local/bin/oc-mirror
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl wget bash tar gzip ca-certificates libgpgme11 jq && \
+        bash ca-certificates libgpgme11 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV OC_URL_AMD64="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz"
-ENV OC_URL_ARM64="https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/stable/arm64/openshift-client-linux.tar.gz"
-ENV OCMIRROR_URL_AMD64="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/oc-mirror.tar.gz"
-ENV OCMIRROR_URL_ARM64="https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/stable/oc-mirror.rhel9.tar.gz"
-
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      OC_URL=$OC_URL_ARM64; \
-      OCMIRROR_URL=$OCMIRROR_URL_ARM64; \
-    else \
-      OC_URL=$OC_URL_AMD64; \
-      OCMIRROR_URL=$OCMIRROR_URL_AMD64; \
-    fi && \
-    wget -O /tmp/oc.tar.gz "$OC_URL" && \
-    tar -xzf /tmp/oc.tar.gz -C /usr/local/bin/ && \
-    chmod +x /usr/local/bin/oc && \
-    rm /tmp/oc.tar.gz && \
-    wget -O /tmp/oc-mirror.tar.gz "$OCMIRROR_URL" && \
-    tar -xzf /tmp/oc-mirror.tar.gz -C /usr/local/bin/ && \
-    chmod +x /usr/local/bin/oc-mirror && \
-    rm /tmp/oc-mirror.tar.gz && \
-    which oc && oc version --client && \
-    which oc-mirror && oc-mirror version && \
-    which node && node --version && \
-    which npm && npm --version && \
-    which curl && curl --version
+RUN set -eux; \
+    which oc-mirror; \
+    oc-mirror version; \
+    which node; \
+    node --version; \
+    which npm; \
+    npm --version
 
 WORKDIR /app
 

--- a/build-for-quay/build-for-quay.sh
+++ b/build-for-quay/build-for-quay.sh
@@ -200,7 +200,7 @@ show_usage() {
       echo
       echo "Examples:"
       echo "  $0                    # Build and push with default version"
-      echo "  $0 --tag v4.3         # Build and push with custom tag"
+      echo "  $0 --tag v4.4         # Build and push with custom tag"
       echo "  $0 --version 4.4      # Build and push with custom version"
       echo "  $0 --no-cleanup       # Build and push without cleanup"
 }

--- a/build-for-quay/build-for-quay.sh
+++ b/build-for-quay/build-for-quay.sh
@@ -11,7 +11,7 @@ PACKAGE_JSON="${PROJECT_DIR}/package.json"
 
 read_package_version() {
     if [ ! -f "${PACKAGE_JSON}" ]; then
-        echo "4.3"
+        echo "4.4"
         return 0
     fi
 
@@ -21,7 +21,7 @@ read_package_version() {
     if [ -n "${package_version}" ]; then
         echo "${package_version}"
     else
-        echo "4.3"
+        echo "4.4"
     fi
 }
 
@@ -201,7 +201,7 @@ show_usage() {
       echo "Examples:"
       echo "  $0                    # Build and push with default version"
       echo "  $0 --tag v4.3         # Build and push with custom tag"
-      echo "  $0 --version 4.3      # Build and push with custom version"
+      echo "  $0 --version 4.4      # Build and push with custom version"
       echo "  $0 --no-cleanup       # Build and push without cleanup"
 }
 

--- a/container-run.sh
+++ b/container-run.sh
@@ -8,8 +8,8 @@ set -e
 
 # Optional behavior flags (can be set via env vars or script args)
 # - BUILD_NO_CACHE=true -> pass --no-cache to podman build
-# - IMAGE_VERSION=4.3   -> set OCI image version label during build
-# - BUILD_VERSION=4.3   -> compatibility alias for IMAGE_VERSION
+# - IMAGE_VERSION=4.4   -> set OCI image version label during build
+# - BUILD_VERSION=4.4   -> compatibility alias for IMAGE_VERSION
 BUILD_NO_CACHE="${BUILD_NO_CACHE:-false}"
 IMAGE_VERSION="${IMAGE_VERSION:-${BUILD_VERSION:-}}"
 
@@ -405,14 +405,14 @@ show_help() {
     echo ""
     echo "Environment Variables:"
     echo "  BUILD_NO_CACHE=true        Disable build cache when building the container image"
-    echo "  IMAGE_VERSION=4.3          Set OCI image version label during build"
-    echo "  BUILD_VERSION=4.3          Compatibility alias for IMAGE_VERSION"
+    echo "  IMAGE_VERSION=4.4          Set OCI image version label during build"
+    echo "  BUILD_VERSION=4.4          Compatibility alias for IMAGE_VERSION"
     echo "  WEB_PORT=$DEFAULT_WEB_PORT            Override the host port used for the web UI"
     echo ""
     echo "Examples:"
     echo "  $0"
     echo "  $0 --build-only"
-    echo "  $0 --build-only --version 4.3"
+    echo "  $0 --build-only --version 4.4"
     echo "  $0 --build-only --no-cache"
     echo "  WEB_PORT=3002 $0 --run-only"
     echo ""

--- a/cron-build.sh
+++ b/cron-build.sh
@@ -13,7 +13,7 @@ LOG_FILE="${LOG_DIR}/build-$(date +%Y%m%d-%H%M%S).log"
 
 read_project_version() {
     if [ ! -f "${PACKAGE_JSON}" ]; then
-        echo "4.3"
+        echo "4.4"
         return 0
     fi
 
@@ -23,7 +23,7 @@ read_project_version() {
     if [ -n "${package_version}" ]; then
         echo "${package_version}"
     else
-        echo "4.3"
+        echo "4.4"
     fi
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-mirror-web-app",
-  "version": "4.3",
+  "version": "4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-mirror-web-app",
-      "version": "4.3",
+      "version": "4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-mirror-web-app",
-  "version": "4.3",
+  "version": "4.4",
   "description": "Web application for OpenShift Container Platform mirroring operations using oc-mirror v2",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preview": "vite preview",
     "server": "tsx watch server/index.ts",
     "server:build": "tsc -p server/tsconfig.json",
-    "audit:fetch-catalogs": "python3 scripts/catalog_metadata.py audit",
+    "audit:fetch-catalogs": "node scripts/audit-fetch-catalogs.mjs",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "format": "prettier --write src/**/*.{ts,tsx,css}",

--- a/scripts/audit-fetch-catalogs.mjs
+++ b/scripts/audit-fetch-catalogs.mjs
@@ -1,0 +1,1419 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+import process from 'process';
+import { fileURLToPath } from 'url';
+import YAML from 'yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+/** Minimum OCP version supported by the app (e.g. 4.16). Catalogs below this are excluded from audit. */
+const MIN_OCP_VERSION = '4.16';
+const BEHAVIOR_REPORT_BASENAME = 'fetch-catalogs-audit';
+const PACKAGE_FILES = new Set(['package.json', 'package.yaml', 'package.yml']);
+const CATALOG_INLINE_FILES = new Set([
+  'catalog.json',
+  'index.json',
+  'catalog.yaml',
+  'catalog.yml',
+  'index.yaml',
+  'index.yml',
+]);
+
+function isOcpVersionSupported(versionStr) {
+  if (!versionStr || typeof versionStr !== 'string') {
+    return false;
+  }
+  const match = versionStr.replace(/^v/, '').match(/^(\d+)\.(\d+)/);
+  if (!match) {
+    return false;
+  }
+  const [minMajor, minMinor] = MIN_OCP_VERSION.split('.').map(Number);
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  return major > minMajor || (major === minMajor && minor >= minMinor);
+}
+
+function parseArgs(argv) {
+  const options = {
+    catalogDataDir: path.join(repoRoot, 'catalog-data'),
+    outputDir: path.join(repoRoot, 'audit-reports'),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if ((arg === '--catalog-data' || arg === '--catalog-data-dir') && argv[i + 1]) {
+      options.catalogDataDir = path.resolve(argv[++i]);
+    } else if (arg === '--output-dir' && argv[i + 1]) {
+      options.outputDir = path.resolve(argv[++i]);
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node scripts/audit-fetch-catalogs.mjs [options]
+
+Options:
+  --catalog-data-dir <path>   Catalog data root (default: ./catalog-data)
+  --output-dir <path>         Report output directory (default: ./audit-reports)
+`);
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function compareVersions(a, b) {
+  const base = (value) => {
+    const match = value.match(/^(\d+\.\d+\.\d+)/);
+    return match ? match[1] : value;
+  };
+
+  const baseA = base(a);
+  const baseB = base(b);
+  const partsA = baseA.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const partsB = baseB.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const maxLength = Math.max(partsA.length, partsB.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const partA = partsA[index] || 0;
+    const partB = partsB[index] || 0;
+    if (partA !== partB) {
+      return partA - partB;
+    }
+  }
+
+  return a.localeCompare(b);
+}
+
+function sortVersions(values) {
+  return uniqueStrings(values).sort(compareVersions);
+}
+
+function sortStrings(values) {
+  return uniqueStrings(values).sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeGeneratedChannels(channels) {
+  if (!Array.isArray(channels)) {
+    return [];
+  }
+
+  if (channels.length === 1 && typeof channels[0] === 'string') {
+    if (channels[0].includes('\n')) {
+      return sortStrings(
+        channels[0]
+          .split('\n')
+          .map((channel) => channel.trim())
+          .filter(Boolean),
+      );
+    }
+
+    if (channels[0].includes(' ')) {
+      return sortStrings(
+        channels[0]
+          .split(' ')
+          .map((channel) => channel.trim())
+          .filter(Boolean),
+      );
+    }
+  }
+
+  return sortStrings(
+    channels
+      .map((channel) => {
+        if (typeof channel === 'string') {
+          return channel.trim();
+        }
+        if (isObject(channel) && typeof channel.name === 'string') {
+          return channel.name.trim();
+        }
+        return '';
+      })
+      .filter(Boolean),
+  );
+}
+
+function extractGeneratedVersions(channelNames, operatorName) {
+  const versions = new Set();
+
+  for (const channel of channelNames) {
+    if (!channel || !channel.trim()) {
+      continue;
+    }
+
+    if (operatorName && channel.includes(`${operatorName}.`)) {
+      const escapedOperatorName = operatorName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const versionWithV = channel.match(new RegExp(`${escapedOperatorName}\\.v(.+)`));
+      if (versionWithV) {
+        versions.add(versionWithV[1]);
+        continue;
+      }
+
+      const versionWithoutV = channel.match(new RegExp(`${escapedOperatorName}\\.(.+)`));
+      if (versionWithoutV) {
+        versions.add(versionWithoutV[1]);
+        continue;
+      }
+    }
+
+    if (operatorName) {
+      const operatorBase = operatorName.replace(/-certified$/, '').replace(/-community$/, '');
+      if (operatorBase !== operatorName && channel.includes(`${operatorBase}.`)) {
+        const escapedOperatorBase = operatorBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const versionWithV = channel.match(new RegExp(`${escapedOperatorBase}\\.v(.+)`));
+        if (versionWithV) {
+          versions.add(versionWithV[1]);
+          continue;
+        }
+
+        const versionWithoutV = channel.match(new RegExp(`${escapedOperatorBase}\\.(.+)`));
+        if (versionWithoutV) {
+          versions.add(versionWithoutV[1]);
+          continue;
+        }
+      }
+    }
+
+    const genericVersionWithV = channel.match(/^[^.]+\.v(.+)/);
+    if (genericVersionWithV) {
+      versions.add(genericVersionWithV[1]);
+      continue;
+    }
+
+    const genericVersionWithoutV = channel.match(/^[^.]+\.(\d+\.\d+\.\d+.*)/);
+    if (genericVersionWithoutV) {
+      versions.add(genericVersionWithoutV[1]);
+      continue;
+    }
+
+    const versionMatch = channel.match(/^v?(\d+\.\d+\.\d+)/);
+    if (versionMatch) {
+      versions.add(versionMatch[1]);
+    }
+  }
+
+  return Array.from(versions).sort(compareVersions);
+}
+
+function getUiFallbackVersions(channelName) {
+  if (!channelName) {
+    return [];
+  }
+
+  const versions = [];
+  const match = channelName.match(/(\d+)\.(\d+)/);
+  if (match) {
+    const major = match[1];
+    const minor = Number.parseInt(match[2], 10);
+    for (let patch = 0; patch <= 10; patch += 1) {
+      versions.push(`${major}.${minor}.${patch}`);
+    }
+    for (let patch = 0; patch <= 5; patch += 1) {
+      versions.push(`${major}.${minor + 1}.${patch}`);
+    }
+    if (minor > 0) {
+      for (let patch = 0; patch <= 5; patch += 1) {
+        versions.push(`${major}.${minor - 1}.${patch}`);
+      }
+    }
+    return sortVersions(versions);
+  }
+
+  return sortVersions([
+    '1.0.0',
+    '1.0.1',
+    '1.0.2',
+    '1.1.0',
+    '1.1.1',
+    '1.2.0',
+    '1.2.1',
+    '2.0.0',
+    '2.0.1',
+  ]);
+}
+
+function extractVersionFromName(value) {
+  if (!value) {
+    return null;
+  }
+
+  const patterns = [
+    /\.v(\d+\.\d+\.\d+(?:[-+._a-zA-Z0-9]*)?)/,
+    /\.(\d+\.\d+\.\d+(?:[-+._a-zA-Z0-9]*)?)/,
+    /^v?(\d+\.\d+\.\d+(?:[-+._a-zA-Z0-9]*)?)$/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = value.match(pattern);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return null;
+}
+
+function extractBundleVersion(bundleDoc) {
+  const properties = Array.isArray(bundleDoc.properties) ? bundleDoc.properties : [];
+  for (const property of properties) {
+    if (property?.type === 'olm.package' && isObject(property.value) && typeof property.value.version === 'string') {
+      return property.value.version;
+    }
+  }
+
+  return extractVersionFromName(bundleDoc.name ?? '');
+}
+
+function normalizeDependencies(dependencies) {
+  const unique = new Map();
+
+  for (const dependency of Array.isArray(dependencies) ? dependencies : []) {
+    if (!isObject(dependency) || typeof dependency.packageName !== 'string' || !dependency.packageName.trim()) {
+      continue;
+    }
+
+    const normalizedDependency = {
+      packageName: dependency.packageName.trim(),
+      versionRange:
+        dependency.versionRange === undefined || dependency.versionRange === null
+          ? null
+          : String(dependency.versionRange),
+    };
+
+    unique.set(
+      `${normalizedDependency.packageName}\u0000${normalizedDependency.versionRange ?? ''}`,
+      normalizedDependency,
+    );
+  }
+
+  return Array.from(unique.values()).sort((left, right) => {
+    const packageCompare = left.packageName.localeCompare(right.packageName);
+    if (packageCompare !== 0) {
+      return packageCompare;
+    }
+    return (left.versionRange ?? '').localeCompare(right.versionRange ?? '');
+  });
+}
+
+function normalizeDependencyMap(value) {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const normalized = {};
+  for (const operatorName of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
+    normalized[operatorName] = normalizeDependencies(value[operatorName]);
+  }
+  return normalized;
+}
+
+function getRange(versions) {
+  if (!versions.length) {
+    return { min: null, max: null };
+  }
+  return {
+    min: versions[0],
+    max: versions[versions.length - 1],
+  };
+}
+
+function getVersionRangeRecord(versions) {
+  const range = getRange(versions);
+  return {
+    minVersion: range.min,
+    maxVersion: range.max,
+  };
+}
+
+function flattenDocuments(documents) {
+  const flattened = [];
+
+  for (const document of documents) {
+    if (Array.isArray(document)) {
+      for (const entry of document) {
+        if (isObject(entry)) {
+          flattened.push(entry);
+        }
+      }
+    } else if (isObject(document)) {
+      flattened.push(document);
+    }
+  }
+
+  return flattened;
+}
+
+function parseJsonDocuments(text) {
+  const documents = [];
+  let index = 0;
+
+  while (index < text.length) {
+    while (index < text.length && /\s/.test(text[index])) {
+      index += 1;
+    }
+
+    if (index >= text.length) {
+      break;
+    }
+
+    const startChar = text[index];
+    if (startChar !== '{' && startChar !== '[') {
+      throw new Error(`Unsupported JSON token "${startChar}" at offset ${index}`);
+    }
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    let endIndex = index;
+
+    for (; endIndex < text.length; endIndex += 1) {
+      const character = text[endIndex];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (character === '\\') {
+          escaped = true;
+          continue;
+        }
+        if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+        continue;
+      }
+
+      if (character === '{' || character === '[') {
+        depth += 1;
+        continue;
+      }
+
+      if (character === '}' || character === ']') {
+        depth -= 1;
+        if (depth === 0) {
+          const slice = text.slice(index, endIndex + 1);
+          documents.push(JSON.parse(slice));
+          index = endIndex + 1;
+          break;
+        }
+      }
+    }
+
+    if (depth !== 0) {
+      throw new Error('Unterminated JSON document');
+    }
+  }
+
+  return documents;
+}
+
+function parseYamlDocuments(text) {
+  return YAML.parseAllDocuments(text)
+    .map((document) => document.toJS())
+    .filter((document) => document !== null && document !== undefined);
+}
+
+async function parseStructuredFile(filePath) {
+  const text = await fs.readFile(filePath, 'utf8');
+  const extension = path.extname(filePath).toLowerCase();
+
+  if (extension === '.json') {
+    return flattenDocuments(parseJsonDocuments(text));
+  }
+
+  if (extension === '.yaml' || extension === '.yml') {
+    return flattenDocuments(parseYamlDocuments(text));
+  }
+
+  return [];
+}
+
+async function listStructuredFiles(operatorDir) {
+  const files = [];
+  const entries = await fs.readdir(operatorDir, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of entries) {
+    const fullPath = path.join(operatorDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'channels' || entry.name === 'bundles') {
+        const nestedEntries = await fs.readdir(fullPath, { withFileTypes: true });
+        nestedEntries.sort((left, right) => left.name.localeCompare(right.name));
+        for (const nestedEntry of nestedEntries) {
+          if (!nestedEntry.isFile()) {
+            continue;
+          }
+          const extension = path.extname(nestedEntry.name).toLowerCase();
+          if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
+            files.push(path.join(fullPath, nestedEntry.name));
+          }
+        }
+      }
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const extension = path.extname(entry.name).toLowerCase();
+    if (extension === '.json' || extension === '.yaml' || extension === '.yml') {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function sourceCategory(filePath, operatorDir) {
+  const relativePath = path.relative(operatorDir, filePath).replace(/\\/g, '/');
+  const baseName = path.basename(filePath).toLowerCase();
+  const parts = relativePath.split('/').map((part) => part.toLowerCase());
+
+  if (PACKAGE_FILES.has(baseName)) {
+    return 'package_explicit';
+  }
+  if (parts.includes('channels') || baseName.startsWith('channel') || baseName.startsWith('channels')) {
+    return 'channel_explicit';
+  }
+  if (parts.includes('bundles') || baseName.startsWith('bundle') || baseName.startsWith('bundles')) {
+    return 'bundle_explicit';
+  }
+  if (CATALOG_INLINE_FILES.has(baseName)) {
+    return 'catalog_inline';
+  }
+  return 'other';
+}
+
+function chooseDocs(records, preferredCategory, kind) {
+  const preferred = records.filter((record) => record.category === preferredCategory && record.kind === kind);
+  if (preferred.length > 0) {
+    return preferred;
+  }
+  return records.filter((record) => record.kind === kind);
+}
+
+function getGeneratedVersionsFromMetadata(generatedOperator) {
+  if (!isObject(generatedOperator)) {
+    return [];
+  }
+
+  const channelVersions = isObject(generatedOperator.channelVersions)
+    ? Object.values(generatedOperator.channelVersions).flatMap((versions) =>
+        Array.isArray(versions)
+          ? versions
+              .map((version) => (typeof version === 'string' ? version.trim() : ''))
+              .filter(Boolean)
+          : [],
+      )
+    : [];
+  const availableVersions = Array.isArray(generatedOperator.availableVersions)
+    ? generatedOperator.availableVersions
+        .map((version) => (typeof version === 'string' ? version.trim() : ''))
+        .filter(Boolean)
+    : [];
+
+  return sortVersions([...channelVersions, ...availableVersions]);
+}
+
+function normalizeGeneratedChannelVersions(channelVersions) {
+  if (!isObject(channelVersions)) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const channelName of Object.keys(channelVersions).sort((left, right) => left.localeCompare(right))) {
+    const versions = channelVersions[channelName];
+    normalized[channelName] = sortVersions(
+      Array.isArray(versions)
+        ? versions.map((version) => (typeof version === 'string' ? version.trim() : '')).filter(Boolean)
+        : [],
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeGeneratedChannelRanges(channelVersionRanges) {
+  if (!isObject(channelVersionRanges)) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const channelName of Object.keys(channelVersionRanges).sort((left, right) => left.localeCompare(right))) {
+    const value = channelVersionRanges[channelName];
+    if (!isObject(value)) {
+      continue;
+    }
+    normalized[channelName] = {
+      minVersion: normalizeString(value.minVersion) || null,
+      maxVersion: normalizeString(value.maxVersion) || null,
+    };
+  }
+
+  return normalized;
+}
+
+function buildExpectedVersionMetadata(rawEntry) {
+  const channelVersions = {};
+  for (const channelName of Object.keys(rawEntry.realVersionsByChannel).sort((left, right) => left.localeCompare(right))) {
+    channelVersions[channelName] = sortVersions(rawEntry.realVersionsByChannel[channelName] || []);
+  }
+
+  return {
+    availableVersions: rawEntry.realVersions,
+    minVersion: rawEntry.realVersions[0] ?? null,
+    maxVersion: rawEntry.realVersions[rawEntry.realVersions.length - 1] ?? null,
+    channelVersions,
+    channelVersionRanges: Object.fromEntries(
+      Object.entries(channelVersions).map(([channelName, versions]) => [channelName, getVersionRangeRecord(versions)]),
+    ),
+  };
+}
+
+function buildGeneratedVersionMetadata(generatedOperator) {
+  if (!isObject(generatedOperator)) {
+    return {
+      availableVersions: [],
+      minVersion: null,
+      maxVersion: null,
+      channelVersions: {},
+      channelVersionRanges: {},
+    };
+  }
+
+  const availableVersions = Array.isArray(generatedOperator.availableVersions)
+    ? generatedOperator.availableVersions
+        .map((version) => (typeof version === 'string' ? version.trim() : ''))
+        .filter(Boolean)
+    : [];
+
+  return {
+    availableVersions: sortVersions(availableVersions),
+    minVersion: normalizeString(generatedOperator.minVersion) || null,
+    maxVersion: normalizeString(generatedOperator.maxVersion) || null,
+    channelVersions: normalizeGeneratedChannelVersions(generatedOperator.channelVersions),
+    channelVersionRanges: normalizeGeneratedChannelRanges(generatedOperator.channelVersionRanges),
+  };
+}
+
+function isPackageDoc(doc, filePath) {
+  if (doc.schema === 'olm.package') {
+    return true;
+  }
+
+  const baseName = path.basename(filePath);
+  return baseName.startsWith('package.') && typeof doc.name === 'string';
+}
+
+function isChannelDoc(doc, filePath) {
+  if (doc.schema === 'olm.channel') {
+    return true;
+  }
+
+  const relativePath = filePath.replace(/\\/g, '/');
+  const baseName = path.basename(filePath);
+  return (
+    (relativePath.includes('/channels/') || baseName === 'channel.json' || baseName === 'channels.json') &&
+    typeof doc.name === 'string' &&
+    Array.isArray(doc.entries)
+  );
+}
+
+function isBundleDoc(doc, filePath) {
+  if (doc.schema === 'olm.bundle') {
+    return true;
+  }
+
+  const relativePath = filePath.replace(/\\/g, '/');
+  const baseName = path.basename(filePath);
+  return (
+    (relativePath.includes('/bundles/') || baseName.startsWith('bundle-')) &&
+    typeof doc.name === 'string' &&
+    Array.isArray(doc.properties)
+  );
+}
+
+async function loadRawOperatorTruth(operatorDir) {
+  const structuredFiles = await listStructuredFiles(operatorDir);
+  const parseWarnings = [];
+  const records = [];
+
+  for (const filePath of structuredFiles) {
+    if (path.basename(filePath) === 'released-bundles.json') {
+      continue;
+    }
+
+    try {
+      const category = sourceCategory(filePath, operatorDir);
+      const documents = await parseStructuredFile(filePath);
+      for (const doc of documents) {
+        if (!isObject(doc)) {
+          continue;
+        }
+
+        if (isPackageDoc(doc, filePath)) {
+          records.push({ kind: 'package', category, doc, filePath });
+        }
+        if (isChannelDoc(doc, filePath)) {
+          records.push({ kind: 'channel', category, doc, filePath });
+        }
+        if (isBundleDoc(doc, filePath)) {
+          records.push({ kind: 'bundle', category, doc, filePath });
+        }
+      }
+    } catch (error) {
+      parseWarnings.push({
+        file: path.relative(repoRoot, filePath),
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const packageRecords = chooseDocs(records, 'package_explicit', 'package');
+  const channelRecords = chooseDocs(records, 'channel_explicit', 'channel');
+  const bundleRecords = chooseDocs(records, 'bundle_explicit', 'bundle');
+
+  if (
+    packageRecords.length === 0 &&
+    channelRecords.length === 0 &&
+    bundleRecords.length === 0 &&
+    parseWarnings.length === 0
+  ) {
+    return null;
+  }
+
+  const dirName = path.basename(operatorDir);
+  const packageDoc = packageRecords.find((entry) => typeof entry.doc.name === 'string')?.doc ?? {};
+  const operatorName =
+    normalizeString(packageDoc.name) ||
+    channelRecords.map((entry) => normalizeString(entry.doc.package)).find(Boolean) ||
+    bundleRecords.map((entry) => normalizeString(entry.doc.package)).find(Boolean) ||
+    dirName;
+  const defaultChannel = normalizeString(packageDoc.defaultChannel) || null;
+  const rawChannels = sortStrings(
+    channelRecords.map((entry) => normalizeString(entry.doc.name)).filter(Boolean),
+  );
+
+  const bundleVersionByName = new Map();
+  const bundleVersions = [];
+  const bundleMetadata = bundleRecords.map((entry) => {
+    const version = extractBundleVersion(entry.doc);
+    if (entry.doc.name && version) {
+      bundleVersionByName.set(entry.doc.name, version);
+    }
+    if (version) {
+      bundleVersions.push(version);
+    }
+    return {
+      filePath: entry.filePath,
+      doc: entry.doc,
+      version,
+    };
+  });
+
+  const realVersionsByChannel = {};
+  for (const channelEntry of channelRecords) {
+    const channelName = normalizeString(channelEntry.doc.name);
+    const entries = Array.isArray(channelEntry.doc.entries) ? channelEntry.doc.entries : [];
+    const versions = entries
+      .map((entry) => {
+        if (!isObject(entry) || typeof entry.name !== 'string') {
+          return null;
+        }
+        return bundleVersionByName.get(entry.name) ?? extractVersionFromName(entry.name);
+      })
+      .filter(Boolean);
+
+    if (versions.length > 0) {
+      const existing = realVersionsByChannel[channelName] || [];
+      realVersionsByChannel[channelName] = sortVersions([...existing, ...versions]);
+    }
+  }
+
+  const realVersions =
+    Object.keys(realVersionsByChannel).length > 0
+      ? sortVersions(Object.values(realVersionsByChannel).flat())
+      : sortVersions(bundleVersions);
+
+  const perChannelRanges = {};
+  for (const [channelName, versions] of Object.entries(realVersionsByChannel)) {
+    perChannelRanges[channelName] = getRange(versions);
+  }
+
+  let selectedBundle = null;
+  if (defaultChannel && realVersionsByChannel[defaultChannel]) {
+    const defaultChannelEntries = channelRecords
+      .filter((entry) => normalizeString(entry.doc.name) === defaultChannel)
+      .flatMap((entry) => (Array.isArray(entry.doc.entries) ? entry.doc.entries : []));
+    const candidates = defaultChannelEntries
+      .filter((entry) => isObject(entry) && typeof entry.name === 'string')
+      .map((entry) => {
+        const bundleMeta = bundleMetadata.find((b) => b.doc.name === entry.name);
+        return bundleMeta && bundleMeta.version ? bundleMeta : null;
+      })
+      .filter(Boolean);
+    if (candidates.length > 0) {
+      candidates.sort((left, right) => compareVersions(left.version, right.version));
+      selectedBundle = candidates[candidates.length - 1];
+    }
+  }
+
+  if (!selectedBundle) {
+    const sortedBundleMetadata = [...bundleMetadata]
+      .filter((b) => b.version)
+      .sort((left, right) => compareVersions(left.version, right.version));
+    if (sortedBundleMetadata.length > 0) {
+      selectedBundle = sortedBundleMetadata[sortedBundleMetadata.length - 1];
+    }
+  }
+
+  let expectedDependencies = [];
+  if (selectedBundle && Array.isArray(selectedBundle.doc.properties)) {
+    expectedDependencies = normalizeDependencies(
+      selectedBundle.doc.properties
+        .filter((property) => property?.type === 'olm.package.required' && isObject(property.value))
+        .map((property) => ({
+          packageName: property.value.packageName,
+          versionRange: property.value.versionRange ?? null,
+        })),
+    );
+  }
+
+  return {
+    dirName,
+    operatorName,
+    defaultChannel,
+    channels: rawChannels,
+    realVersionsByChannel,
+    realVersions,
+    perChannelRanges,
+    bundleCount: bundleRecords.length,
+    structuredFiles: structuredFiles.map((filePath) => path.relative(repoRoot, filePath)),
+    parseWarnings,
+    expectedDependencies,
+  };
+}
+
+function addIssue(issues, category, details) {
+  issues.push({ category, details });
+}
+
+function formatList(values, maxItems = 6) {
+  if (!values || values.length === 0) {
+    return '(none)';
+  }
+  if (values.length <= maxItems) {
+    return values.join(', ');
+  }
+  return `${values.slice(0, maxItems).join(', ')} ... (+${values.length - maxItems} more)`;
+}
+
+function formatRange(min, max) {
+  if (!min && !max) {
+    return '(none)';
+  }
+  if (min && max) {
+    return `${min} -> ${max}`;
+  }
+  return min || max || '(none)';
+}
+
+function countCategories(issueLists) {
+  const counts = {};
+  for (const issue of issueLists) {
+    counts[issue.category] = (counts[issue.category] || 0) + 1;
+  }
+  return counts;
+}
+
+async function readJsonFile(filePath, fallback = null) {
+  try {
+    const text = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+async function readJsonFileWithDiagnostics(filePath, fallback = null) {
+  try {
+    const text = await fs.readFile(filePath, 'utf8');
+    return {
+      value: JSON.parse(text),
+      error: null,
+    };
+  } catch (error) {
+    const kind =
+      error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT'
+        ? 'missing'
+        : error instanceof SyntaxError
+          ? 'parse_error'
+          : 'read_error';
+
+    return {
+      value: fallback,
+      error: {
+        kind,
+        path: path.relative(repoRoot, filePath),
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+function createCatalogJsonIssue(prefix, error) {
+  if (!error) {
+    return null;
+  }
+
+  const category =
+    error.kind === 'missing'
+      ? `${prefix}_file_missing`
+      : error.kind === 'parse_error'
+        ? `${prefix}_file_parse_error`
+        : `${prefix}_file_read_error`;
+
+  return {
+    category,
+    details: {
+      path: error.path,
+      message: error.message,
+    },
+  };
+}
+
+async function discoverCatalogSnapshots(catalogDataDir) {
+  const snapshots = [];
+  const entries = await fs.readdir(catalogDataDir, { withFileTypes: true });
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const catalogType = entry.name;
+    const catalogTypeDir = path.join(catalogDataDir, catalogType);
+    const versionEntries = await fs.readdir(catalogTypeDir, { withFileTypes: true });
+
+    for (const versionEntry of versionEntries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (!versionEntry.isDirectory()) {
+        continue;
+      }
+
+      const version = versionEntry.name;
+      if (!isOcpVersionSupported(version)) {
+        continue;
+      }
+      const snapshotDir = path.join(catalogTypeDir, version);
+      try {
+        await fs.access(path.join(snapshotDir, 'operators.json'));
+        snapshots.push({
+          catalogType,
+          version,
+          key: `${catalogType}:${version}`,
+          snapshotDir,
+        });
+      } catch {
+        // Ignore directories without generated operator data.
+      }
+    }
+  }
+
+  return snapshots;
+}
+
+async function auditSnapshot(snapshot, masterDependencies) {
+  const operatorsPath = path.join(snapshot.snapshotDir, 'operators.json');
+  const dependenciesPath = path.join(snapshot.snapshotDir, 'dependencies.json');
+  const configsDir = path.join(snapshot.snapshotDir, 'configs');
+
+  const generatedOperatorsResult = await readJsonFileWithDiagnostics(operatorsPath, []);
+  const dependenciesResult = await readJsonFileWithDiagnostics(dependenciesPath, null);
+  const generatedOperators = Array.isArray(generatedOperatorsResult.value) ? generatedOperatorsResult.value : [];
+  const perCatalogDependencies = dependenciesResult.error ? null : dependenciesResult.value;
+  const masterCatalogDependencies = isObject(masterDependencies) ? masterDependencies[snapshot.key] ?? null : null;
+  const hasGeneratedOperatorData = generatedOperatorsResult.error === null;
+  const hasPerCatalogDependencyData = dependenciesResult.error === null;
+  const catalogIssues = [];
+
+  const operatorsCatalogIssue = createCatalogJsonIssue('operators', generatedOperatorsResult.error);
+  if (operatorsCatalogIssue) {
+    catalogIssues.push(operatorsCatalogIssue);
+  }
+
+  const dependenciesCatalogIssue = createCatalogJsonIssue('dependencies', dependenciesResult.error);
+  if (dependenciesCatalogIssue) {
+    catalogIssues.push(dependenciesCatalogIssue);
+  }
+
+  const rawOperatorEntries = [];
+  try {
+    const operatorDirEntries = await fs.readdir(configsDir, { withFileTypes: true });
+    for (const operatorDirEntry of operatorDirEntries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (operatorDirEntry.isDirectory()) {
+        const rawEntry = await loadRawOperatorTruth(path.join(configsDir, operatorDirEntry.name));
+        if (rawEntry) {
+          rawOperatorEntries.push(rawEntry);
+        }
+      }
+    }
+  } catch {
+    // Leave rawOperatorEntries empty; missing configs will be reported through generated-vs-raw mismatches.
+  }
+
+  const rawByName = new Map();
+  const rawByDir = new Map();
+  for (const rawEntry of rawOperatorEntries) {
+    rawByName.set(rawEntry.operatorName, rawEntry);
+    rawByDir.set(rawEntry.dirName, rawEntry);
+  }
+
+  const generatedByName = new Map();
+  for (const generatedOperator of generatedOperators) {
+    generatedByName.set(generatedOperator.name, generatedOperator);
+  }
+
+  const operatorFindings = [];
+  const seenGenerated = new Set();
+
+  for (const rawEntry of rawOperatorEntries) {
+    const generatedOperator = hasGeneratedOperatorData
+      ? generatedByName.get(rawEntry.operatorName) ??
+        (rawEntry.dirName !== rawEntry.operatorName ? generatedByName.get(rawEntry.dirName) : null) ??
+        null
+      : null;
+
+    const issues = [];
+    const generatedChannels = normalizeGeneratedChannels(generatedOperator?.channels);
+    const rawChannels = rawEntry.channels;
+    const realVersions = rawEntry.realVersions;
+    const generatedVersionSource = generatedOperator?.name ?? rawEntry.operatorName;
+    const serverDerivedVersions = getGeneratedVersionsFromMetadata(generatedOperator);
+    const derivedChannelVersions =
+      serverDerivedVersions.length > 0
+        ? []
+        : extractGeneratedVersions(generatedChannels, generatedVersionSource);
+    const serverVersions = serverDerivedVersions.length > 0 ? serverDerivedVersions : derivedChannelVersions;
+    const fallbackChannelName =
+      generatedOperator?.defaultChannel ||
+      generatedChannels[0] ||
+      rawEntry.defaultChannel ||
+      rawChannels[0] ||
+      '';
+    const uiFallbackVersions = getUiFallbackVersions(fallbackChannelName);
+    const realRange = getRange(realVersions);
+    const serverRange = getRange(serverVersions);
+    const fallbackRange = getRange(uiFallbackVersions);
+    const expectedVersionMetadata = buildExpectedVersionMetadata(rawEntry);
+    const generatedVersionMetadata = buildGeneratedVersionMetadata(generatedOperator);
+
+    if (hasGeneratedOperatorData && !generatedOperator) {
+      addIssue(issues, 'raw_operator_missing_from_generated', {
+        operatorDir: rawEntry.dirName,
+      });
+    } else if (generatedOperator) {
+      seenGenerated.add(generatedOperator.name);
+    }
+
+    if (rawEntry.parseWarnings.length > 0) {
+      addIssue(issues, 'raw_parse_warning', {
+        files: rawEntry.parseWarnings,
+      });
+    }
+
+    if (generatedOperator && generatedOperator.name !== rawEntry.operatorName) {
+      addIssue(issues, 'generated_name_mismatch', {
+        generatedName: generatedOperator.name,
+        rawName: rawEntry.operatorName,
+      });
+    }
+
+    if (generatedOperator) {
+      if ((generatedOperator.defaultChannel ?? null) !== rawEntry.defaultChannel) {
+        addIssue(issues, 'default_channel_mismatch', {
+          generatedDefaultChannel: generatedOperator.defaultChannel ?? null,
+          rawDefaultChannel: rawEntry.defaultChannel,
+        });
+      }
+
+      if (rawChannels.length > 0 && generatedChannels.length === 0) {
+        addIssue(issues, 'empty_channel_list', {
+          rawChannels,
+        });
+      }
+
+      const missingChannels = rawChannels.filter((channel) => !generatedChannels.includes(channel));
+      const unexpectedChannels = generatedChannels.filter((channel) => !rawChannels.includes(channel));
+
+      if (missingChannels.length > 0) {
+        addIssue(issues, 'missing_channels', {
+          missingChannels,
+        });
+      }
+
+      if (unexpectedChannels.length > 0) {
+        addIssue(issues, 'unexpected_channels', {
+          unexpectedChannels,
+        });
+      }
+    }
+
+    if (realVersions.length === 0 && (rawChannels.length > 0 || rawEntry.bundleCount > 0)) {
+      addIssue(issues, 'no_real_versions_found', {
+        rawChannels,
+        bundleCount: rawEntry.bundleCount,
+      });
+    }
+
+    if (hasGeneratedOperatorData && realVersions.length > 0 && serverVersions.length === 0) {
+      addIssue(issues, 'ui_version_fallback_risk', {
+        rawRange: realRange,
+        fallbackRange,
+        fallbackChannelName,
+      });
+    }
+
+    if (generatedOperator) {
+      if (JSON.stringify(generatedVersionMetadata.availableVersions) !== JSON.stringify(expectedVersionMetadata.availableVersions)) {
+        addIssue(issues, 'available_versions_mismatch', {
+          expected: expectedVersionMetadata.availableVersions,
+          generated: generatedVersionMetadata.availableVersions,
+        });
+      }
+
+      if (
+        generatedVersionMetadata.minVersion !== expectedVersionMetadata.minVersion ||
+        generatedVersionMetadata.maxVersion !== expectedVersionMetadata.maxVersion
+      ) {
+        addIssue(issues, 'min_max_mismatch', {
+          expected: {
+            minVersion: expectedVersionMetadata.minVersion,
+            maxVersion: expectedVersionMetadata.maxVersion,
+          },
+          generated: {
+            minVersion: generatedVersionMetadata.minVersion,
+            maxVersion: generatedVersionMetadata.maxVersion,
+          },
+        });
+      }
+
+      if (JSON.stringify(generatedVersionMetadata.channelVersions) !== JSON.stringify(expectedVersionMetadata.channelVersions)) {
+        addIssue(issues, 'channel_versions_mismatch', {
+          expected: expectedVersionMetadata.channelVersions,
+          generated: generatedVersionMetadata.channelVersions,
+        });
+      }
+
+      if (
+        JSON.stringify(generatedVersionMetadata.channelVersionRanges) !==
+        JSON.stringify(expectedVersionMetadata.channelVersionRanges)
+      ) {
+        addIssue(issues, 'channel_ranges_mismatch', {
+          expected: expectedVersionMetadata.channelVersionRanges,
+          generated: generatedVersionMetadata.channelVersionRanges,
+        });
+      }
+    }
+
+    const expectedDependencies = rawEntry.expectedDependencies;
+    const generatedDependencies = hasPerCatalogDependencyData
+      ? normalizeDependencies(generatedOperator ? perCatalogDependencies?.[generatedOperator.name] : [])
+      : [];
+    const masterDependenciesForOperator =
+      hasPerCatalogDependencyData && generatedOperator
+        ? normalizeDependencies(masterCatalogDependencies?.[generatedOperator.name] ?? [])
+        : [];
+
+    if (hasPerCatalogDependencyData && generatedOperator) {
+      if (expectedDependencies.length > 0 && generatedDependencies.length === 0) {
+        addIssue(issues, 'dependencies_missing', {
+          expectedDependencies,
+        });
+      } else if (JSON.stringify(expectedDependencies) !== JSON.stringify(generatedDependencies)) {
+        addIssue(issues, 'dependencies_mismatch', {
+          expectedDependencies,
+          generatedDependencies,
+        });
+      }
+
+      if (JSON.stringify(generatedDependencies) !== JSON.stringify(masterDependenciesForOperator)) {
+        addIssue(issues, 'master_dependencies_operator_mismatch', {
+          generatedDependencies,
+          masterDependencies: masterDependenciesForOperator,
+        });
+      }
+    }
+
+    if (issues.length > 0) {
+      operatorFindings.push({
+        operator: generatedOperator?.name ?? rawEntry.operatorName,
+        catalogKey: snapshot.key,
+        operatorDir: path.relative(repoRoot, path.join(configsDir, rawEntry.dirName)),
+        generated: generatedOperator
+          ? {
+              name: generatedOperator.name,
+              defaultChannel: generatedOperator.defaultChannel ?? null,
+              channels: generatedChannels,
+            }
+          : null,
+        raw: {
+          operatorName: rawEntry.operatorName,
+          operatorDirName: rawEntry.dirName,
+          defaultChannel: rawEntry.defaultChannel,
+          channels: rawChannels,
+          structuredFiles: rawEntry.structuredFiles,
+        },
+        versions: {
+          rawVersions: realVersions,
+          rawRange: realRange,
+          perChannelRanges: rawEntry.perChannelRanges,
+          expectedMetadata: expectedVersionMetadata,
+          generatedMetadata: generatedVersionMetadata,
+          serverDerivedVersions: serverVersions,
+          serverRange,
+          uiFallbackVersions,
+          uiFallbackRange: fallbackRange,
+          fallbackChannelName,
+        },
+        dependencies: {
+          expected: expectedDependencies,
+          generated: generatedDependencies,
+          master: masterDependenciesForOperator,
+        },
+        issues,
+      });
+    }
+  }
+
+  if (hasGeneratedOperatorData) {
+    for (const generatedOperator of generatedOperators) {
+      if (seenGenerated.has(generatedOperator.name)) {
+        continue;
+      }
+
+      const rawMatch =
+        rawByName.get(generatedOperator.name) ??
+        rawByDir.get(generatedOperator.name) ??
+        null;
+
+      if (rawMatch) {
+        continue;
+      }
+
+      operatorFindings.push({
+        operator: generatedOperator.name,
+        catalogKey: snapshot.key,
+        operatorDir: null,
+        generated: {
+          name: generatedOperator.name,
+          defaultChannel: generatedOperator.defaultChannel ?? null,
+          channels: normalizeGeneratedChannels(generatedOperator.channels),
+        },
+        raw: null,
+        versions: null,
+        dependencies: {
+          expected: [],
+          generated: hasPerCatalogDependencyData
+            ? normalizeDependencies(perCatalogDependencies?.[generatedOperator.name])
+            : [],
+          master: hasPerCatalogDependencyData
+            ? normalizeDependencies(masterCatalogDependencies?.[generatedOperator.name])
+            : [],
+        },
+        issues: [
+          {
+            category: 'generated_operator_missing_from_raw',
+            details: {},
+          },
+        ],
+      });
+    }
+  }
+
+  if (hasPerCatalogDependencyData && perCatalogDependencies === null) {
+    catalogIssues.push({
+      category: 'dependencies_file_missing',
+      details: {
+        path: path.relative(repoRoot, dependenciesPath),
+      },
+    });
+  }
+
+  if (hasPerCatalogDependencyData && masterCatalogDependencies === null && perCatalogDependencies !== null) {
+    catalogIssues.push({
+      category: 'master_dependencies_missing',
+      details: {
+        catalogKey: snapshot.key,
+      },
+    });
+  } else if (
+    hasPerCatalogDependencyData &&
+    perCatalogDependencies !== null &&
+    JSON.stringify(normalizeDependencyMap(perCatalogDependencies)) !==
+      JSON.stringify(normalizeDependencyMap(masterCatalogDependencies))
+  ) {
+    catalogIssues.push({
+      category: 'master_dependencies_mismatch',
+      details: {
+        catalogKey: snapshot.key,
+      },
+    });
+  }
+
+  return {
+    catalogKey: snapshot.key,
+    catalogType: snapshot.catalogType,
+    version: snapshot.version,
+    generatedOperatorCount: generatedOperators.length,
+    rawOperatorCount: rawOperatorEntries.length,
+    operators: operatorFindings,
+    catalogIssues,
+    categoryCounts: countCategories([
+      ...operatorFindings.flatMap((finding) => finding.issues),
+      ...catalogIssues,
+    ]),
+  };
+}
+
+function buildMarkdownReport(report) {
+  const lines = [];
+
+  lines.push('# Fetch Catalogs Audit Report');
+  lines.push('');
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push(`Catalog data: \`${path.relative(repoRoot, report.catalogDataDir)}\``);
+  lines.push(`JSON report: \`${path.relative(repoRoot, report.jsonReportPath)}\``);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- Catalog snapshots audited: ${report.summary.catalogSnapshots}`);
+  lines.push(`- Operators audited: ${report.summary.operatorsAudited}`);
+  lines.push(`- Operators with issues: ${report.summary.operatorsWithIssues}`);
+  lines.push(`- Catalog snapshots with issues: ${report.summary.catalogSnapshotsWithIssues}`);
+  lines.push(`- Total issues: ${report.summary.totalIssues}`);
+  lines.push('');
+  lines.push('## Issue Counts');
+  lines.push('');
+
+  for (const [category, count] of Object.entries(report.summary.issueCounts).sort((left, right) => right[1] - left[1])) {
+    lines.push(`- \`${category}\`: ${count}`);
+  }
+
+  for (const catalog of report.catalogs) {
+    if (catalog.operators.length === 0 && catalog.catalogIssues.length === 0) {
+      continue;
+    }
+
+    lines.push('');
+    lines.push(`## ${catalog.catalogKey}`);
+    lines.push('');
+    lines.push(`- Generated operators: ${catalog.generatedOperatorCount}`);
+    lines.push(`- Raw operator directories: ${catalog.rawOperatorCount}`);
+    lines.push(`- Operators with issues: ${catalog.operators.length}`);
+
+    if (catalog.catalogIssues.length > 0) {
+      lines.push(`- Catalog-level issues: ${catalog.catalogIssues.map((issue) => `\`${issue.category}\``).join(', ')}`);
+    }
+
+    for (const finding of catalog.operators) {
+      const categories = finding.issues.map((issue) => `\`${issue.category}\``).join(', ');
+      const generatedChannels = formatList(finding.generated?.channels ?? []);
+      const rawChannels = formatList(finding.raw?.channels ?? []);
+      const rawRange = finding.versions ? formatRange(finding.versions.rawRange.min, finding.versions.rawRange.max) : '(none)';
+      const serverRange = finding.versions ? formatRange(finding.versions.serverRange.min, finding.versions.serverRange.max) : '(none)';
+      const fallbackRange = finding.versions
+        ? formatRange(finding.versions.uiFallbackRange.min, finding.versions.uiFallbackRange.max)
+        : '(none)';
+      const expectedDependencyCount = finding.dependencies?.expected?.length ?? 0;
+      const generatedDependencyCount = finding.dependencies?.generated?.length ?? 0;
+
+      lines.push(
+        `- \`${finding.operator}\`: ${categories}; generated channels=${generatedChannels}; raw channels=${rawChannels}; raw range=${rawRange}; server range=${serverRange}; UI fallback=${fallbackRange}; dependencies expected/generated=${expectedDependencyCount}/${generatedDependencyCount}`,
+      );
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const catalogDataDir = options.catalogDataDir;
+  const outputDir = options.outputDir;
+
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const snapshots = await discoverCatalogSnapshots(catalogDataDir);
+  const masterDependencies = await readJsonFile(path.join(catalogDataDir, 'dependencies.json'), {});
+  const catalogs = [];
+
+  for (const snapshot of snapshots) {
+    catalogs.push(await auditSnapshot(snapshot, masterDependencies));
+  }
+
+  const operatorFindings = catalogs.flatMap((catalog) => catalog.operators);
+  const catalogIssues = catalogs.flatMap((catalog) => catalog.catalogIssues);
+  const allIssues = [
+    ...operatorFindings.flatMap((finding) => finding.issues),
+    ...catalogIssues,
+  ];
+
+  const jsonReportPath = path.join(outputDir, `${BEHAVIOR_REPORT_BASENAME}.json`);
+  const markdownReportPath = path.join(outputDir, `${BEHAVIOR_REPORT_BASENAME}.md`);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    repoRoot,
+    catalogDataDir,
+    jsonReportPath,
+    markdownReportPath,
+    summary: {
+      catalogSnapshots: catalogs.length,
+      catalogSnapshotsWithIssues: catalogs.filter((catalog) => catalog.operators.length > 0 || catalog.catalogIssues.length > 0).length,
+      operatorsAudited: catalogs.reduce((total, catalog) => total + catalog.rawOperatorCount, 0),
+      operatorsWithIssues: operatorFindings.length,
+      totalIssues: allIssues.length,
+      issueCounts: countCategories(allIssues),
+    },
+    notableFindings: {},
+    catalogs,
+  };
+
+  const markdownReport = buildMarkdownReport(report);
+
+  await fs.writeFile(jsonReportPath, JSON.stringify(report, null, 2));
+  await fs.writeFile(markdownReportPath, markdownReport);
+
+  console.log(`Catalog snapshots audited: ${report.summary.catalogSnapshots}`);
+  console.log(`Operators audited: ${report.summary.operatorsAudited}`);
+  console.log(`Operators with issues: ${report.summary.operatorsWithIssues}`);
+  console.log(`Total issues: ${report.summary.totalIssues}`);
+  console.log(`JSON report: ${path.relative(repoRoot, jsonReportPath)}`);
+  console.log(`Markdown report: ${path.relative(repoRoot, markdownReportPath)}`);
+}
+
+main().catch((error) => {
+  console.error('Failed to audit catalog data:', error);
+  process.exitCode = 1;
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,6 @@ import { isPathAvailable } from './pathAvailability.js';
 import {
   type ChannelObject,
   parseOcMirrorVersion,
-  parseOcVersion,
   getCatalogNameFromUrl,
   getCatalogDescription,
   compareVersionStrings,
@@ -237,9 +236,8 @@ const upload = multer({ storage });
 
 async function getSystemInfo(): Promise<SystemInfo> {
   try {
-    const [ocMirrorVersion, ocVersion, systemArch] = await Promise.all([
+    const [ocMirrorVersion, systemArch] = await Promise.all([
       execAsync('oc-mirror version').catch(() => ({ stdout: 'Not available', stderr: '' })),
-      execAsync('oc version --client').catch(() => ({ stdout: 'Not available', stderr: '' })),
       execAsync('uname -m').catch(() => ({ stdout: 'Not available', stderr: '' }))
     ]);
 
@@ -251,7 +249,7 @@ async function getSystemInfo(): Promise<SystemInfo> {
 
     return {
       ocMirrorVersion: parseOcMirrorVersion(ocMirrorVersion.stdout.trim()),
-      ocVersion: parseOcVersion(ocVersion.stdout.trim()),
+      ocVersion: 'Not available',
       systemArchitecture: systemArch.stdout.trim(),
       availableDiskSpace: availableSpace,
       totalDiskSpace: totalSpace
@@ -322,8 +320,7 @@ async function getOperation(operationId: string): Promise<OperationRecord> {
 }
 
 async function getSystemHealth(): Promise<string> {
-  let ocOk = false, ocMirrorOk = false;
-  try { await execAsync('oc version --client'); ocOk = true; } catch {}
+  let ocMirrorOk = false;
   try { await execAsync('oc-mirror version'); ocMirrorOk = true; } catch {}
 
   let diskOk = false;
@@ -335,7 +332,7 @@ async function getSystemHealth(): Promise<string> {
     diskOk = availableSpace > 1_000_000_000;
   } catch {}
 
-  if (!ocOk || !ocMirrorOk) return 'error';
+  if (!ocMirrorOk) return 'error';
   if (!diskOk) return 'degraded';
   return 'healthy';
 }
@@ -582,6 +579,15 @@ const operatorCache: OperatorCache = {
   channels: {},
   lastUpdate: null,
   cacheTimeout: 3600000
+};
+
+/**
+ * Integration tests only: when `process.env.VITEST` is set, the next matching request
+ * throws before normal handling so the route `catch` returns 500 (not fake fallback data).
+ */
+export const __routeTestHooks = {
+  failNextCatalogsGet: false,
+  failNextOperatorsGet: false
 };
 
 function isCacheValid(): boolean {
@@ -904,6 +910,10 @@ app.get('/api/channels', async (req: Request, res: Response) => {
 
 app.get('/api/catalogs', async (req: Request, res: Response) => {
   try {
+    if (process.env.VITEST === 'true' && __routeTestHooks.failNextCatalogsGet) {
+      __routeTestHooks.failNextCatalogsGet = false;
+      throw new Error('forced failure for catalogs route (test)');
+    }
     const cache = await updateOperatorCache();
     const catalogs = cache.catalogs.map(catalog => ({
       name: catalog.name,
@@ -914,32 +924,16 @@ app.get('/api/catalogs', async (req: Request, res: Response) => {
     res.json(catalogs);
   } catch (error: any) {
     console.error('Error fetching catalogs:', error);
-    const fallbackCatalogs = [
-      {
-        name: 'redhat-operator-index',
-        url: 'registry.redhat.io/redhat/redhat-operator-index',
-        description: 'Red Hat certified operators',
-        operatorCount: 0
-      },
-      {
-        name: 'certified-operator-index',
-        url: 'registry.redhat.io/redhat/certified-operator-index',
-        description: 'Certified operators from partners',
-        operatorCount: 0
-      },
-      {
-        name: 'community-operator-index',
-        url: 'registry.redhat.io/redhat/community-operator-index',
-        description: 'Community operators',
-        operatorCount: 0
-      }
-    ];
-    res.json(fallbackCatalogs);
+    res.status(500).json({ error: 'Failed to get catalogs' });
   }
 });
 
 app.get('/api/operators', async (req: Request, res: Response) => {
   try {
+    if (process.env.VITEST === 'true' && __routeTestHooks.failNextOperatorsGet) {
+      __routeTestHooks.failNextOperatorsGet = false;
+      throw new Error('forced failure for operators route (test)');
+    }
     const { catalog, detailed } = req.query;
 
     if (catalog) {
@@ -1001,29 +995,7 @@ app.get('/api/operators', async (req: Request, res: Response) => {
     }
   } catch (error: any) {
     console.error('Error fetching operators:', error);
-    const fallbackOperators = [
-      'advanced-cluster-management',
-      'elasticsearch-operator',
-      'kiali-ossm',
-      'servicemeshoperator',
-      'openshift-pipelines-operator-rh',
-      'serverless-operator',
-      'jaeger-product',
-      'rhods-operator',
-      'openshift-gitops-operator',
-      'openshift-logging',
-      'openshift-monitoring',
-      'cluster-logging',
-      'local-storage-operator',
-      'node-feature-discovery-operator',
-      'performance-addon-operator',
-      'ptp-operator',
-      'sriov-network-operator',
-      'bare-metal-event-relay',
-      'cluster-baremetal-operator',
-      'metal3-operator'
-    ];
-    res.json(fallbackOperators);
+    res.status(500).json({ error: 'Failed to get operators' });
   }
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,7 +47,6 @@ interface OperationRecord {
 
 interface SystemInfo {
   ocMirrorVersion: string;
-  ocVersion: string;
   systemArchitecture: string;
   availableDiskSpace: number;
   totalDiskSpace: number;
@@ -249,7 +248,6 @@ async function getSystemInfo(): Promise<SystemInfo> {
 
     return {
       ocMirrorVersion: parseOcMirrorVersion(ocMirrorVersion.stdout.trim()),
-      ocVersion: 'Not available',
       systemArchitecture: systemArch.stdout.trim(),
       availableDiskSpace: availableSpace,
       totalDiskSpace: totalSpace
@@ -258,7 +256,6 @@ async function getSystemInfo(): Promise<SystemInfo> {
     console.error('Error getting system info:', error);
     return {
       ocMirrorVersion: 'Not available',
-      ocVersion: 'Not available',
       systemArchitecture: 'Not available',
       availableDiskSpace: 0,
       totalDiskSpace: 0
@@ -734,7 +731,6 @@ app.get('/api/system/status', async (req: Request, res: Response) => {
     const systemHealth = await getSystemHealth();
     res.json({
       ocMirrorVersion: systemInfo.ocMirrorVersion,
-      ocVersion: systemInfo.ocVersion,
       systemHealth
     });
   } catch (error: any) {

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -25,23 +25,6 @@ export function parseOcMirrorVersion(raw: string): string {
   return 'Not available';
 }
 
-export function parseOcVersion(raw: string): string {
-  const lines = raw.split('\n');
-  for (const line of lines) {
-    if (line.includes('Client Version:')) {
-      const match = line.match(/Client Version:\s*(\S+)/);
-      if (match) {
-        return match[1];
-      }
-    }
-  }
-  const fallback = raw.match(/(\d+\.\d+\.\d+)/);
-  if (fallback) {
-    return fallback[1];
-  }
-  return 'Not available';
-}
-
 export function getCatalogNameFromUrl(catalogUrl: string): string {
   if (catalogUrl.includes('redhat-operator-index')) {
     return 'redhat-operator-index';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,7 @@ const AppLayout: React.FC = () => {
               </div>
             </ToolbarItem>
             <ToolbarItem align={{ default: 'alignEnd' }}>
-              <Label color="blue">v4.3</Label>
+              <Label color="blue">v4.4</Label>
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -22,7 +22,6 @@ import {
 } from '@patternfly/react-core';
 import {
   SyncAltIcon,
-  CogIcon,
   CheckCircleIcon,
   TimesCircleIcon,
   InProgressIcon,
@@ -51,7 +50,6 @@ interface Operation {
 
 interface SystemStatus {
   ocMirrorVersion: string;
-  ocVersion: string;
   systemHealth: string;
 }
 
@@ -146,7 +144,6 @@ const Dashboard: React.FC = () => {
   const [recentOperations, setRecentOperations] = useState<Operation[]>([]);
   const [systemStatus, setSystemStatus] = useState<SystemStatus>({
     ocMirrorVersion: '',
-    ocVersion: '',
     systemHealth: 'unknown',
   });
   const [loading, setLoading] = useState(true);
@@ -206,7 +203,7 @@ const Dashboard: React.FC = () => {
           </CardHeader>
           <CardBody>
             <Grid hasGutter>
-              <GridItem md={4}>
+              <GridItem md={6}>
                 <Card isPlain>
                   <CardBody>
                     <DescriptionList>
@@ -223,24 +220,7 @@ const Dashboard: React.FC = () => {
                   </CardBody>
                 </Card>
               </GridItem>
-              <GridItem md={4}>
-                <Card isPlain>
-                  <CardBody>
-                    <DescriptionList>
-                      <DescriptionListGroup>
-                        <DescriptionListTerm>
-                          <CogIcon style={{ marginRight: '0.5rem' }} />
-                          OC Version
-                        </DescriptionListTerm>
-                        <DescriptionListDescription>
-                          {systemStatus.ocVersion || 'Not available'}
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
-                    </DescriptionList>
-                  </CardBody>
-                </Card>
-              </GridItem>
-              <GridItem md={4}>
+              <GridItem md={6}>
                 <Card isPlain>
                   <CardBody>
                     <DescriptionList>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -22,6 +22,7 @@ import {
 } from '@patternfly/react-core';
 import {
   SyncAltIcon,
+  CogIcon,
   CheckCircleIcon,
   TimesCircleIcon,
   InProgressIcon,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -64,7 +64,6 @@ interface Settings {
 
 interface SystemInfo {
   ocMirrorVersion: string;
-  ocVersion: string;
   systemArchitecture: string;
   availableDiskSpace: string | number;
   totalDiskSpace: string | number;
@@ -94,7 +93,6 @@ const SettingsPage: React.FC = () => {
   const [settings, setSettings] = useState<Settings>({ ...defaultSettings });
   const [systemInfo, setSystemInfo] = useState<SystemInfo>({
     ocMirrorVersion: '',
-    ocVersion: '',
     systemArchitecture: '',
     availableDiskSpace: '',
     totalDiskSpace: '',
@@ -420,14 +418,6 @@ const SettingsPage: React.FC = () => {
                         <CardTitle>OC Mirror Version</CardTitle>
                       </CardHeader>
                       <CardBody>{systemInfo.ocMirrorVersion || 'Not available'}</CardBody>
-                    </Card>
-                  </GridItem>
-                  <GridItem span={6}>
-                    <Card isPlain>
-                      <CardHeader>
-                        <CardTitle>OC Version</CardTitle>
-                      </CardHeader>
-                      <CardBody>{systemInfo.ocVersion || 'Not available'}</CardBody>
                     </Card>
                   </GridItem>
                   <GridItem span={6}>

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -34,6 +34,11 @@ test.describe('Navigation', () => {
     await expect(page.getByText('OC Mirror v2 Web Application')).toBeVisible();
   });
 
+  test('masthead shows current app version badge', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('v4.4')).toBeVisible();
+  });
+
   test('Red Hat logo is visible', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('img').first()).toBeVisible();

--- a/tests/integration/catalogs.test.ts
+++ b/tests/integration/catalogs.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+import { __routeTestHooks } from '../../server/index.js';
 import { getTestApp } from './helpers/testApp.js';
 
 describe('Catalogs API', () => {
@@ -27,6 +28,14 @@ describe('Catalogs API', () => {
         expect(typeof catalog.operatorCount).toBe('number');
         expect(catalog.operatorCount).toBeGreaterThanOrEqual(1);
       });
+    });
+
+    it('returns 500 when the catalogs route handler fails', async () => {
+      __routeTestHooks.failNextCatalogsGet = true;
+      const res = await request.get('/api/catalogs');
+      expect(res.status).toBe(500);
+      expect(res.body).toHaveProperty('error');
+      expect(String(res.body.error)).toMatch(/Failed to get catalogs/i);
     });
   });
 });

--- a/tests/integration/operators.test.ts
+++ b/tests/integration/operators.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+import { __routeTestHooks } from '../../server/index.js';
 import { getTestApp } from './helpers/testApp.js';
 
 describe('Operators API', () => {
@@ -40,6 +41,14 @@ describe('Operators API', () => {
       expect(acm.defaultChannel).toBe('release-2.16');
       expect(acm.allChannels).toContain('release-2.15');
       expect(acm.allChannels).toContain('release-2.16');
+    });
+
+    it('returns 500 when the operators route handler fails (no catalog filter)', async () => {
+      __routeTestHooks.failNextOperatorsGet = true;
+      const res = await request.get('/api/operators');
+      expect(res.status).toBe(500);
+      expect(res.body).toHaveProperty('error');
+      expect(String(res.body.error)).toMatch(/Failed to get operators/i);
     });
   });
 

--- a/tests/integration/system.test.ts
+++ b/tests/integration/system.test.ts
@@ -28,7 +28,6 @@ describe('System API', () => {
       const res = await request.get('/api/system/info');
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('ocMirrorVersion');
-      expect(res.body).toHaveProperty('ocVersion');
       expect(res.body).toHaveProperty('systemArchitecture');
       expect(typeof res.body.availableDiskSpace).toBe('number');
       expect(typeof res.body.totalDiskSpace).toBe('number');
@@ -40,7 +39,6 @@ describe('System API', () => {
       const res = await request.get('/api/system/status');
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('ocMirrorVersion');
-      expect(res.body).toHaveProperty('ocVersion');
       expect(res.body).toHaveProperty('systemHealth');
       expect(['healthy', 'degraded', 'error']).toContain(res.body.systemHealth);
     });

--- a/tests/scripts/auditFetchCatalogs.test.ts
+++ b/tests/scripts/auditFetchCatalogs.test.ts
@@ -1,0 +1,133 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+import { execFile } from 'child_process';
+import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import process from 'process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = path.join(process.cwd(), 'scripts', 'audit-fetch-catalogs.mjs');
+
+type SnapshotFixture = {
+  operatorsJson: string;
+  dependenciesJson?: string;
+  rawDocs?: unknown[];
+};
+
+async function createAuditFixture(snapshot: SnapshotFixture) {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'audit-fetch-catalogs-'));
+  const catalogDataDir = path.join(rootDir, 'catalog-data');
+  const outputDir = path.join(rootDir, 'audit-reports');
+  const snapshotDir = path.join(catalogDataDir, 'redhat-operator-index', 'v4.16');
+  const operatorDir = path.join(snapshotDir, 'configs', 'example-operator');
+
+  await mkdir(operatorDir, { recursive: true });
+  await writeFile(path.join(catalogDataDir, 'dependencies.json'), '{}\n');
+  await writeFile(path.join(snapshotDir, 'operators.json'), snapshot.operatorsJson);
+  await writeFile(path.join(snapshotDir, 'dependencies.json'), snapshot.dependenciesJson ?? '{}\n');
+
+  if (snapshot.rawDocs) {
+    await writeFile(path.join(operatorDir, 'catalog.json'), JSON.stringify(snapshot.rawDocs, null, 2));
+  }
+
+  return { catalogDataDir, outputDir };
+}
+
+async function runAuditFixture(snapshot: SnapshotFixture) {
+  const { catalogDataDir, outputDir } = await createAuditFixture(snapshot);
+
+  await execFileAsync(process.execPath, [
+    scriptPath,
+    '--catalog-data-dir',
+    catalogDataDir,
+    '--output-dir',
+    outputDir,
+  ]);
+
+  const reportPath = path.join(outputDir, 'fetch-catalogs-audit.json');
+  return JSON.parse(await readFile(reportPath, 'utf8'));
+}
+
+function buildRawOperatorDocs(versions: string[]) {
+  return [
+    {
+      schema: 'olm.package',
+      name: 'example-operator',
+      defaultChannel: 'stable',
+    },
+    {
+      schema: 'olm.channel',
+      name: 'stable',
+      package: 'example-operator',
+      entries: versions.map((version) => ({
+        name: `example-operator.v${version}`,
+      })),
+    },
+    ...versions.map((version) => ({
+      schema: 'olm.bundle',
+      name: `example-operator.v${version}`,
+      package: 'example-operator',
+      properties: [
+        {
+          type: 'olm.package',
+          value: {
+            packageName: 'example-operator',
+            version,
+          },
+        },
+      ],
+    })),
+  ];
+}
+
+describe('audit-fetch-catalogs', () => {
+  it('flags exact version metadata mismatches even when min/max still match', async () => {
+    const report = await runAuditFixture({
+      operatorsJson: JSON.stringify([
+        {
+          name: 'example-operator',
+          defaultChannel: 'stable',
+          channels: ['stable'],
+          availableVersions: ['1.0.0', '1.0.1', '1.0.2'],
+          minVersion: '1.0.0',
+          maxVersion: '1.0.2',
+          channelVersions: {
+            stable: ['1.0.0', '1.0.1', '1.0.2'],
+          },
+          channelVersionRanges: {
+            stable: {
+              minVersion: '1.0.0',
+              maxVersion: '1.0.2',
+            },
+          },
+        },
+      ]),
+      rawDocs: buildRawOperatorDocs(['1.0.0', '1.0.2']),
+    });
+
+    const finding = report.catalogs[0].operators[0];
+    const issueCategories = finding.issues.map((issue: { category: string }) => issue.category);
+
+    expect(issueCategories).toContain('available_versions_mismatch');
+    expect(issueCategories).toContain('channel_versions_mismatch');
+    expect(report.summary.issueCounts.available_versions_mismatch).toBe(1);
+  });
+
+  it('surfaces generated JSON parse errors without raw-vs-generated mismatch noise', async () => {
+    const report = await runAuditFixture({
+      operatorsJson: '{"name": "broken"',
+      rawDocs: buildRawOperatorDocs(['1.0.0']),
+    });
+
+    const catalog = report.catalogs[0];
+    const catalogIssueCategories = catalog.catalogIssues.map((issue: { category: string }) => issue.category);
+
+    expect(catalogIssueCategories).toContain('operators_file_parse_error');
+    expect(report.summary.issueCounts.operators_file_parse_error).toBe(1);
+    expect(report.summary.issueCounts.raw_operator_missing_from_generated ?? 0).toBe(0);
+    expect(catalog.operators).toEqual([]);
+  });
+});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseOcMirrorVersion,
-  parseOcVersion,
   getCatalogNameFromUrl,
   getCatalogDescription,
   compareVersionStrings,
@@ -26,22 +25,6 @@ describe('parseOcMirrorVersion', () => {
 
   it('returns "Not available" when no version found', () => {
     expect(parseOcMirrorVersion('no version here')).toBe('Not available');
-  });
-});
-
-describe('parseOcVersion', () => {
-  it('extracts from Client Version line', () => {
-    const output = `Client Version: 4.15.0
-Server Version: 4.14.0`;
-    expect(parseOcVersion(output)).toBe('4.15.0');
-  });
-
-  it('uses fallback regex when Client Version not present', () => {
-    expect(parseOcVersion('4.21.0')).toBe('4.21.0');
-  });
-
-  it('returns "Not available" when no version found', () => {
-    expect(parseOcVersion('oc version')).toBe('Not available');
   });
 });
 


### PR DESCRIPTION
## Summary

- **Dockerfile optimization**: Multi-stage build improvements for smaller, faster container images
- **Version 4.4 release prep**: Bumped package.json, aligned UI badge, API docs, and build scripts to v4.4
- **Remove ocVersion**: Cleaned up the deprecated `ocVersion` field from the system API, UI, and docs
- **Audit script improvements**: Tracked `scripts/audit-fetch-catalogs.mjs` in git, patched it to surface JSON parse errors and compare exact version metadata (not just min/max ranges), wired `npm run audit:fetch-catalogs` to the JS entrypoint, and added CLI regression tests
- **CI fix**: Restored Dashboard CogIcon import broken by prior refactor

## Changes (21 files, +1669 / -167)

| Commit | Description |
|--------|-------------|
| `fc45d98` | `chore(release): prepare app version 4.4` |
| `1a68c4b` | `Remove ocVersion from system API, UI, and docs` |
| `b3d819c` | `fix(ci): restore Dashboard CogIcon import` |
| `ddd4a73` | `fix(audit): track JS fetch catalogs audit script` |
| `0b6540a` | `fix(ui): update visible app version to v4.4` |

## Test plan

- [x] `npm run test` — 14 files, 106 tests passed
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — production build succeeded
- [x] `npx playwright test` — 28 E2E tests passed
- [x] Navigation smoke test including v4.4 badge check — passed
- [x] GitHub Actions CI (run 23849339637) — all 4 jobs green


Made with [Cursor](https://cursor.com)